### PR TITLE
Add option to disable cross-SKU edges

### DIFF
--- a/Baseline/MARL_algorithm/config/envs/replenishment.yaml
+++ b/Baseline/MARL_algorithm/config/envs/replenishment.yaml
@@ -8,4 +8,5 @@ env_args:
   mode: train
   time_limit: 100
   reward: "reward2_enhanced"
+  cross_sku_edges: True
   

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ make_env("{task_name}")
 from ReplenishmentEnv import make_env
 make_env("{config_name}", config_dir="{config_dir}")
 ```
+* To speed up large multi-store scenarios, set `cross_sku_edges: False` in the
+  YAML config to remove pairwise SKU edges when building the graph.
 
 ## Run OR algorithm
 * Install MABIM

--- a/ReplenishmentEnv/config/sku100.2_stores.standard.yml
+++ b/ReplenishmentEnv/config/sku100.2_stores.standard.yml
@@ -16,6 +16,7 @@ env:
   lookback_len: 21
   integerization_sku: True
   warmup: replenish_by_last_demand
+  cross_sku_edges: False
   sku_list: ReplenishmentEnv/data/sku2778/sku100.sku_list.csv
 
 warehouse:

--- a/ReplenishmentEnv/env/replenishment_env.py
+++ b/ReplenishmentEnv/env/replenishment_env.py
@@ -64,6 +64,7 @@ class ReplenishmentEnv(Env):
         self.vis_path = os.path.join("output", datetime.now().strftime('%Y%m%d_%H%M%S')) if vis_path is None else vis_path
  
         self.load_config(config_path, update_config)
+        self.cross_sku_edges = self.config["env"].get("cross_sku_edges", True)
         self.build_supply_chain()
 
         self.load_data()
@@ -439,10 +440,11 @@ class ReplenishmentEnv(Env):
                     src = self.warehouse_to_id[warehouse] * self.sku_count + i
                     dst = self.warehouse_to_id[downstream] * self.sku_count + i
                     edges.append((src, dst))
-        for warehouse in self.warehouse_list:
-            base = self.warehouse_to_id[warehouse] * self.sku_count
-            for i in range(self.sku_count):
-                for j in range(i + 1, self.sku_count):
-                    edges.append((base + i, base + j))
-                    edges.append((base + j, base + i))
+        if self.cross_sku_edges:
+            for warehouse in self.warehouse_list:
+                base = self.warehouse_to_id[warehouse] * self.sku_count
+                for i in range(self.sku_count):
+                    for j in range(i + 1, self.sku_count):
+                        edges.append((base + i, base + j))
+                        edges.append((base + j, base + i))
         return np.array(edges, dtype=np.int64).T

--- a/ReplenishmentEnv/wrapper/observation_wrapper_for_old_code.py
+++ b/ReplenishmentEnv/wrapper/observation_wrapper_for_old_code.py
@@ -267,10 +267,11 @@ class ObservationWrapper4OldCode(gym.Wrapper):
                     src = self.env.warehouse_to_id[warehouse] * sku_count + i
                     dst = self.env.warehouse_to_id[downstream] * sku_count + i
                     edges.append((src, dst))
-        for warehouse in self.env.warehouse_list:
-            base = self.env.warehouse_to_id[warehouse] * sku_count
-            for i in range(sku_count):
-                for j in range(i + 1, sku_count):
-                    edges.append((base + i, base + j))
-                    edges.append((base + j, base + i))
+        if getattr(self.env, "cross_sku_edges", True):
+            for warehouse in self.env.warehouse_list:
+                base = self.env.warehouse_to_id[warehouse] * sku_count
+                for i in range(sku_count):
+                    for j in range(i + 1, sku_count):
+                        edges.append((base + i, base + j))
+                        edges.append((base + j, base + i))
         return np.array(edges, dtype=np.int64).T


### PR DESCRIPTION
## Summary
- add `cross_sku_edges` parameter to `ReplenishmentEnv` and wrapper
- expose option in MARL env config and sample scenario
- document `cross_sku_edges` usage in README

## Testing
- `python -m compileall -q ReplenishmentEnv Baseline/MARL_algorithm/config/envs/replenishment.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685736952028832490c0b40524b5d09d